### PR TITLE
feat: add snaptocenter option for draggables within dropzones

### DIFF
--- a/src/allonsh.js
+++ b/src/allonsh.js
@@ -2,87 +2,137 @@
 class Allonsh {
   constructor(draggableSelector) {
     this.draggables = document.querySelectorAll(draggableSelector);
-    this.draggedEl = null;
+    this.draggedElement = null;
     this.offsetX = 0;
     this.offsetY = 0;
+    this._snapToCenterEnabled = false;
+    this._dropzones = new Set(); // Track registered dropzones
 
     this._onMouseDown = this._onMouseDown.bind(this);
     this._onMouseMove = this._onMouseMove.bind(this);
     this._onMouseUp = this._onMouseUp.bind(this);
 
-    this.init();
+    this._initialize();
   }
 
-  init() {
-    this.draggables.forEach(el => {
-      el.style.position = 'absolute'; // ensure draggable is positioned
-      el.style.cursor = 'grab';
-      el.addEventListener('mousedown', this._onMouseDown);
+  _initialize() {
+    this.draggables.forEach(element => {
+      element.style.position = 'absolute';
+      element.style.cursor = 'grab';
+      element.addEventListener('mousedown', this._onMouseDown);
     });
   }
 
-  _onMouseDown(e) {
-    this.draggedEl = e.target;
-    const rect = this.draggedEl.getBoundingClientRect();
+  _onMouseDown(event) {
+    this.draggedElement = event.target;
+    const rect = this.draggedElement.getBoundingClientRect();
 
-    this.offsetX = e.clientX - rect.left;
-    this.offsetY = e.clientY - rect.top;
+    this.offsetX = event.clientX - rect.left;
+    this.offsetY = event.clientY - rect.top;
 
-    this.draggedEl.style.cursor = 'grabbing';
-    this.draggedEl.style.zIndex = '1000';
+    this.draggedElement.style.cursor = 'grabbing';
+    this.draggedElement.style.zIndex = '1000';
 
     document.addEventListener('mousemove', this._onMouseMove);
     document.addEventListener('mouseup', this._onMouseUp);
 
-    // Dispatch custom event dragstart
-    this.draggedEl.dispatchEvent(new CustomEvent('allonsh-dragstart', {
-      detail: { originalEvent: e }
+    this.draggedElement.dispatchEvent(new CustomEvent('allonsh-dragstart', {
+      detail: { originalEvent: event }
     }));
   }
 
-  _onMouseMove(e) {
-    if (!this.draggedEl) return;
+  _onMouseMove(event) {
+    if (!this.draggedElement) return;
 
-    // Move element to follow cursor with offset
-    this.draggedEl.style.left = (e.clientX - this.offsetX) + 'px';
-    this.draggedEl.style.top = (e.clientY - this.offsetY) + 'px';
+    this.draggedElement.style.left = (event.clientX - this.offsetX) + 'px';
+    this.draggedElement.style.top = (event.clientY - this.offsetY) + 'px';
 
-    // Temporarily disable pointer events to detect element below
-    this.draggedEl.style.pointerEvents = 'none';
-    const elBelow = document.elementFromPoint(e.clientX, e.clientY);
-    this.draggedEl.style.pointerEvents = 'auto';
+    this.draggedElement.style.pointerEvents = 'none';
+    const elementBelow = document.elementFromPoint(event.clientX, event.clientY);
+    this.draggedElement.style.pointerEvents = 'auto';
 
-    if (elBelow && elBelow !== this.draggedEl) {
-      // Dispatch dragover event on element below
-      elBelow.dispatchEvent(new CustomEvent('allonsh-dragover', {
-        detail: { draggedEl: this.draggedEl, originalEvent: e }
+    if (elementBelow && elementBelow !== this.draggedElement) {
+      elementBelow.dispatchEvent(new CustomEvent('allonsh-dragover', {
+        detail: { draggedEl: this.draggedElement, originalEvent: event }
       }));
     }
   }
 
-  _onMouseUp(e) {
-    if (!this.draggedEl) return;
+  _onMouseUp(event) {
+    if (!this.draggedElement) return;
 
-    // Temporarily disable pointer events to detect element below
-    this.draggedEl.style.pointerEvents = 'none';
-    const elBelow = document.elementFromPoint(e.clientX, e.clientY);
-    this.draggedEl.style.pointerEvents = 'auto';
+    this.draggedElement.style.pointerEvents = 'none';
+    const elementBelow = document.elementFromPoint(event.clientX, event.clientY);
+    this.draggedElement.style.pointerEvents = 'auto';
 
-    // Dispatch drop event on element below
-    if (elBelow && elBelow !== this.draggedEl) {
-      elBelow.dispatchEvent(new CustomEvent('allonsh-drop', {
-        detail: { draggedEl: this.draggedEl, originalEvent: e }
+    if (elementBelow && elementBelow !== this.draggedElement) {
+      elementBelow.dispatchEvent(new CustomEvent('allonsh-drop', {
+        detail: { draggedEl: this.draggedElement, originalEvent: event }
       }));
+
+      // Auto-snap to center if enabled AND dropped on a registered dropzone
+      if (this._snapToCenterEnabled && this._dropzones.has(elementBelow)) {
+        this._applySnapToCenter(this.draggedElement, elementBelow);
+      }
     }
 
-    this.draggedEl.style.cursor = 'grab';
-    this.draggedEl.style.zIndex = '';
+    this.draggedElement.style.cursor = 'grab';
+    this.draggedElement.style.zIndex = '';
 
-    this.draggedEl = null;
+    this.draggedElement = null;
 
     document.removeEventListener('mousemove', this._onMouseMove);
     document.removeEventListener('mouseup', this._onMouseUp);
   }
+
+  /**
+   * Registers a dropzone and optional drop handler.
+   */
+  registerDropzone(selector, onDrop) {
+    const dropzone = document.querySelector(selector);
+    if (!dropzone) return;
+
+    this._dropzones.add(dropzone); // Track this dropzone
+
+    dropzone.addEventListener('allonsh-dragover', () => {
+      dropzone.classList.add('dragover');
+    });
+
+    dropzone.addEventListener('allonsh-drop', (event) => {
+      dropzone.classList.remove('dragover');
+      if (typeof onDrop === 'function') {
+        onDrop(event.detail.draggedEl, dropzone);
+      }
+    });
+
+    document.addEventListener('allonsh-dragstart', () => {
+      dropzone.classList.remove('dragover');
+    });
+  }
+
+  /**
+   * Enables or disables automatic snap-to-center behavior on drop.
+   */
+  enableSnapToCenter(enable = true) {
+    this._snapToCenterEnabled = enable;
+  }
+
+  /**
+   * Applies snap-to-center logic to a dragged element.
+   * @private
+   */
+   _applySnapToCenter(draggedElement, dropzone) {
+  const dropRect = dropzone.getBoundingClientRect();
+  const dragRect = draggedElement.getBoundingClientRect();
+
+  const scrollX = window.scrollX || window.pageXOffset;
+  const scrollY = window.scrollY || window.pageYOffset;
+
+  draggedElement.style.left =
+    scrollX + dropRect.left + dropRect.width / 2 - dragRect.width / 2 + 'px';
+  draggedElement.style.top =
+    scrollY + dropRect.top + dropRect.height / 2 - dragRect.height / 2 + 'px';
+}
 }
 
 // Export default for ES modules


### PR DESCRIPTION
## Description

- Introduced a configurable option to enable/disable snapping dragged elements to the center of registered dropzones.
- When enabled, dropped elements automatically align to the center of the dropzone.
- Enhances drop feedback and layout consistency.

## Related Issue

- Closes #2 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Using local server.

## Checklist

- [x] My code follows the project’s style guidelines  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [x] Any dependent changes have been merged and published in downstream modules  

## Additional Notes

Add any other context or screenshots about the pull request here.
