### PR TITLE
add snapping modes for draggable and update demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,7 +58,8 @@
       const dropzone = document.getElementById('dropzone');
 
       const dragManager = new Allonsh('.draggable');
-      dragManager.enableSnapToCenter(true);
+      dragManager.enableSnapping(true);
+      dragManager.setSnapMode('bottom-right');
 
       dragManager.registerDropzone('#dropzone', (draggedEl, dropzone) => {
         console.log('Dropped:', draggedEl.textContent);


### PR DESCRIPTION
## Description
- Replaced snapToCenter with a new enableSnapping flag
- Introduced snapMode option (center, top-left, top-right, bottom-left, bottom-right, edge)
- Default snapping mode is center
- Refactored _applySnapToCenter → _applySnap for modularity
- Added setSnapMode() and enableSnapping() public methods

## Related Issue

- Closes N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Tested using local server.

## Checklist

- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Add any other context or screenshots about the pull request here.
