### PR TITLE
Add build support for ES modile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0-rc] - 2025-09-07
+
+### Added
+
+- Added support for ESM builds to generate ES modules
+
 ## [0.2.0-beta] - 2025-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ media="(prefers-color-scheme: light)"
 
 Lightweight, dependency-free drag-and-drop with precise native target detection and easy customization.
 
-![Version Badge](https://img.shields.io/badge/Current_Version-v0.2.0--beta-blue.svg)
+![Version Badge](https://img.shields.io/badge/Current_Version-v0.2.0--rc-blue.svg)
 
 ## Features
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -47,7 +47,7 @@
           Allonsh.js
           <span class="demo-header__demoText"> Demo </span>
 
-          <span class="demo-allonsh__currentVersion"> v0.2.0-beta </span>
+          <span class="demo-allonsh__currentVersion"> v0.2.0-rc </span>
         </h2>
       </div>
       <div class="github-links">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allonsh",
-  "version": "0.2.0-beta",
+  "version": "0.2.0-rc",
   "description": "Lightweight, dependency-free drag-and-drop with precise native target detection and easy customization.",
   "main": "src/Allonsh.js",
   "directories": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,17 @@ export default [
         plugins: [terser()],
         sourcemap: false,
       },
+      {
+        file: 'dist/allonsh.esm.js',
+        format: 'es',
+        sourcemap: false,
+      },
+      {
+        file: 'dist/allonsh.esm.min.js',
+        format: 'es',
+        plugins: [terser()],
+        sourcemap: false,
+      },
     ],
     plugins: [resolve(), commonjs()],
   },


### PR DESCRIPTION
## Description

- Added Rollup configuration to generate ES module builds and updated the package version to a release candidate.

## Related Issue

- Closes N/A

## Type of Change

- [x] New feature

## How Has This Been Tested?

Using `npm run build`

## Checklist

- [x] My code follows the project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ES module build outputs, enabling native ESM imports and better bundler compatibility/tree‑shaking.
- Documentation
  - Updated CHANGELOG with 0.2.0-rc release notes highlighting ESM support.
  - Updated README version badge to 0.2.0-rc.
- Chores
  - Bumped package version to 0.2.0-rc.
  - Updated demo page version labels to reflect 0.2.0-rc.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->